### PR TITLE
Expand col into color

### DIFF
--- a/src/js/helpers/Test.js
+++ b/src/js/helpers/Test.js
@@ -4,31 +4,31 @@ $scss-color: #0B486B;
 /* Less variables */
 @less-color: #0B486B;
 
---col-named: tomato;
+--color-named: tomato;
 
---col-hex: #79BD9A;
---col-hexa: #79BD9A99;
+--color-hex: #79BD9A;
+--color-hexa: #79BD9A99;
 
---col-hx: #79B;
---col-hxa: #79B9;
+--color-hx: #79B;
+--color-hxa: #79B9;
 
---col-rgb: rgb(0, 128, 128);
---col-rgba-1: rgba(50, 128, 128, .5);
---col-rgba-2: rgba(50, 128, 128, 0.5);
---col-rgba-3: rgba(50, 128, 128, 20.5%);
---col-rgba-4: rgba(50, 128, 128, 50%);
+--color-rgb: rgb(0, 128, 128);
+--color-rgba-1: rgba(50, 128, 128, .5);
+--color-rgba-2: rgba(50, 128, 128, 0.5);
+--color-rgba-3: rgba(50, 128, 128, 20.5%);
+--color-rgba-4: rgba(50, 128, 128, 50%);
 
---col-hsl: hsl(202, 81.4%, 30.1%);
---col-hsla-1: hsla(100, 51.4%, 55.1%, .5);
---col-hsla-2: hsla(100, 51.4%, 55.1%, 20.5%);
---col-hsla-3: hsla(100, 51.4%, 55.1%, 0.5);
---col-hsla-4: hsla(100, 51.4%, 55.1%, 50%);
+--color-hsl: hsl(202, 81.4%, 30.1%);
+--color-hsla-1: hsla(100, 51.4%, 55.1%, .5);
+--color-hsla-2: hsla(100, 51.4%, 55.1%, 20.5%);
+--color-hsla-3: hsla(100, 51.4%, 55.1%, 0.5);
+--color-hsla-4: hsla(100, 51.4%, 55.1%, 50%);
 
---col-keyword-t: transparent;
---col-keyword-c: currentColor;
+--color-keyword-t: transparent;
+--color-keyword-c: currentColor;
 
---col-white: hsl(0, 0%, 100%);
---col-black: hsl(0, 0%, 0%);
+--color-white: hsl(0, 0%, 100%);
+--color-black: hsl(0, 0%, 0%);
 `;
 
 class Test {

--- a/src/js/helpers/addExampleControls.js
+++ b/src/js/helpers/addExampleControls.js
@@ -33,7 +33,7 @@ export function addExampleControls ({
 function getCodes (colors) {
   return colors
     .reduce((prev, item, index) => {
-      prev.push(`--col-${index + 1}: ${item};`);
+      prev.push(`--color-${index + 1}: ${item};`);
       return prev;
     }, [])
     .join('\n');

--- a/src/scss/blocks/codes.scss
+++ b/src/scss/blocks/codes.scss
@@ -23,12 +23,12 @@
     margin-top: .5em;
     padding: .25em;
     box-sizing: border-box;
-    border: 1px solid var(--col-2);
+    border: 1px solid var(--color-2);
     border-radius: .25rem;
     font: 15px/1.4 Trebuchet MS, sans-serif;
 
     &::placeholder {
-      color: var(--col-3);
+      color: var(--color-3);
       font-style: italic;
     }
   }
@@ -43,7 +43,7 @@
     width: 1.75em;
     height: 1.75em;
     border-radius: .25rem;
-    border: 1px solid var(--col-2);
+    border: 1px solid var(--color-2);
 
     & + & {
       margin-left: 1rem;
@@ -53,6 +53,6 @@
   &__tip {
     margin-top: .5em;
     font-size: .9em;
-    color: var(--col-3);
+    color: var(--color-3);
   }
 }

--- a/src/scss/blocks/header.scss
+++ b/src/scss/blocks/header.scss
@@ -12,8 +12,8 @@
   margin: 0 1.25em;
   padding: 0 .25em;
   text-align: center;
-  background: var(--col-deepblue);
-  color: var(--col-1);
+  background: var(--color-deepblue);
+  color: var(--color-1);
 
   &::before,
   &::after {
@@ -25,11 +25,11 @@
 
   &::before {
     left: -.5em;
-    background: linear-gradient(to right bottom, var(--body-bg) 50%, var(--col-deepblue) 0);
+    background: linear-gradient(to right bottom, var(--body-bg) 50%, var(--color-deepblue) 0);
   }
   &::after {
     right: -.5em;
-    background: linear-gradient(to left top, var(--body-bg) 50%, var(--col-deepblue) 0);
+    background: linear-gradient(to left top, var(--body-bg) 50%, var(--color-deepblue) 0);
   }
 }
 
@@ -42,7 +42,7 @@
   border-bottom: 1px dashed;
   text-decoration: none;
   line-height: 1.2;
-  color: var(--col-3);
+  color: var(--color-3);
 }
 .page__header-link--about {
   order: -1;

--- a/src/scss/blocks/options.scss
+++ b/src/scss/blocks/options.scss
@@ -57,7 +57,7 @@
 }
 
 .options__range:focus + .options__range-value {
-  background: var(--col-2);
+  background: var(--color-2);
 }
 
 .options__label--radio {
@@ -68,7 +68,7 @@
   }
 
   .options__label-text {
-    --border-color: var(--col-2);
+    --border-color: var(--color-2);
     padding: .5em;
     border-radius: .5em;
     box-shadow: 0 0 0 2px var(--border-color) inset;
@@ -77,10 +77,10 @@
   }
 
   &:hover .options__label-text {
-    --border-color: var(--col-green);
+    --border-color: var(--color-green);
   }
 
   input:checked + .options__label-text {
-    --border-color: var(--col-deepblue);
+    --border-color: var(--color-deepblue);
   }
 }

--- a/src/scss/blocks/palette.scss
+++ b/src/scss/blocks/palette.scss
@@ -49,6 +49,7 @@
   padding: .5rem;
   box-sizing: border-box;
   opacity: .75;
+  white-space: nowrap;
 }
 
 .palette__cell--base .palette__cell-content {

--- a/src/scss/blocks/palette.scss
+++ b/src/scss/blocks/palette.scss
@@ -15,7 +15,7 @@
 
 .palette__tip {
   padding: .5rem;
-  color: var(--col-3);
+  color: var(--color-3);
 }
 
 .palette__tip--darker {
@@ -24,7 +24,7 @@
 .palette__tip--base {
   justify-self: center;
   white-space: nowrap;
-  color: var(--col-4-lightest);
+  color: var(--color-4-lightest);
 }
 
 .palette__view {
@@ -35,7 +35,7 @@
   &:empty::before {
     content: "";
     grid-column: 1 / -1;
-    background: var(--col-2-light);
+    background: var(--color-2-light);
     height: 3.75rem;
     border-radius: 1rem;
   }
@@ -52,7 +52,7 @@
 }
 
 .palette__cell--base .palette__cell-content {
-  border: solid var(--col-4);
+  border: solid var(--color-4);
   border-width: 0 2px;
 }
 .palette__cell--first-line .palette__cell-content {
@@ -79,7 +79,7 @@
 .palette__cell--no-color {
   background-image: repeating-linear-gradient(-45deg,
     transparent, transparent 5px,
-    var(--col-2-light) 0, var(--col-2-light) 6px
+    var(--color-2-light) 0, var(--color-2-light) 6px
   );
   box-shadow: 0 0 0 2px #FFF inset;
 }

--- a/src/scss/global/base.scss
+++ b/src/scss/global/base.scss
@@ -23,7 +23,7 @@ H4 {
 H2 {
   margin-bottom: 1em;
   padding-bottom: .25em;
-  border-bottom: 1px solid var(--col-2);
+  border-bottom: 1px solid var(--color-2);
 }
 
 H3 {

--- a/src/scss/global/colors.scss
+++ b/src/scss/global/colors.scss
@@ -1,68 +1,68 @@
 :root {
-  --col-1-darkest: hsl(0, 0%, 79%);
-  --col-1-darker: hsl(0, 0%, 86%);
-  --col-1-dark: hsl(0, 0%, 93%);
-  --col-1: hsl(0, 0%, 100%);
-  --col-1-light: hsl(0, 0%, 107%);
-  --col-1-lighter: hsl(0, 0%, 114%);
-  --col-1-lightest: hsl(0, 0%, 121%);
+  --color-1-darkest: hsl(0, 0%, 79%);
+  --color-1-darker: hsl(0, 0%, 86%);
+  --color-1-dark: hsl(0, 0%, 93%);
+  --color-1: hsl(0, 0%, 100%);
+  --color-1-light: hsl(0, 0%, 107%);
+  --color-1-lighter: hsl(0, 0%, 114%);
+  --color-1-lightest: hsl(0, 0%, 121%);
 
-  --col-2-darkest: hsl(0, 0%, 65.7%);
-  --col-2-darker: hsl(0, 0%, 72.7%);
-  --col-2-dark: hsl(0, 0%, 79.7%);
-  --col-2: hsl(0, 0%, 86.7%);
-  --col-2-light: hsl(0, 0%, 93.7%);
-  --col-2-lighter: hsl(0, 0%, 100.7%);
-  --col-2-lightest: hsl(0, 0%, 107.7%);
+  --color-2-darkest: hsl(0, 0%, 65.7%);
+  --color-2-darker: hsl(0, 0%, 72.7%);
+  --color-2-dark: hsl(0, 0%, 79.7%);
+  --color-2: hsl(0, 0%, 86.7%);
+  --color-2-light: hsl(0, 0%, 93.7%);
+  --color-2-lighter: hsl(0, 0%, 100.7%);
+  --color-2-lightest: hsl(0, 0%, 107.7%);
 
-  --col-3-darkest: hsl(0, 0%, 29.7%);
-  --col-3-darker: hsl(0, 0%, 36.7%);
-  --col-3-dark: hsl(0, 0%, 43.7%);
-  --col-3: hsl(0, 0%, 50.7%);
-  --col-3-light: hsl(0, 0%, 57.7%);
-  --col-3-lighter: hsl(0, 0%, 64.7%);
-  --col-3-lightest: hsl(0, 0%, 71.7%);
+  --color-3-darkest: hsl(0, 0%, 29.7%);
+  --color-3-darker: hsl(0, 0%, 36.7%);
+  --color-3-dark: hsl(0, 0%, 43.7%);
+  --color-3: hsl(0, 0%, 50.7%);
+  --color-3-light: hsl(0, 0%, 57.7%);
+  --color-3-lighter: hsl(0, 0%, 64.7%);
+  --color-3-lightest: hsl(0, 0%, 71.7%);
 
 
-  --col-4-darkest: hsl(0, 0%, -21%);
-  --col-4-darker: hsl(0, 0%, -14%);
-  --col-4-dark: hsl(0, 0%, -7%);
-  --col-4: hsl(0, 0%, 0%);
-  --col-4-light: hsl(0, 0%, 7%);
-  --col-4-lighter: hsl(0, 0%, 14%);
-  --col-4-lightest: hsl(0, 0%, 21%);
+  --color-4-darkest: hsl(0, 0%, -21%);
+  --color-4-darker: hsl(0, 0%, -14%);
+  --color-4-dark: hsl(0, 0%, -7%);
+  --color-4: hsl(0, 0%, 0%);
+  --color-4-light: hsl(0, 0%, 7%);
+  --color-4-lighter: hsl(0, 0%, 14%);
+  --color-4-lightest: hsl(0, 0%, 21%);
 
-  --col-green-darkest: hsl(100, 51.5%, 33.9%);
-  --col-green-darker: hsl(100, 51.5%, 40.9%);
-  --col-green-dark: hsl(100, 51.5%, 47.9%);
-  --col-green: hsl(100, 51.5%, 54.9%);
-  --col-green-light: hsl(100, 51.5%, 61.9%);
-  --col-green-lighter: hsl(100, 51.5%, 68.9%);
-  --col-green-lightest: hsl(100, 51.5%, 75.9%);
+  --color-green-darkest: hsl(100, 51.5%, 33.9%);
+  --color-green-darker: hsl(100, 51.5%, 40.9%);
+  --color-green-dark: hsl(100, 51.5%, 47.9%);
+  --color-green: hsl(100, 51.5%, 54.9%);
+  --color-green-light: hsl(100, 51.5%, 61.9%);
+  --color-green-lighter: hsl(100, 51.5%, 68.9%);
+  --color-green-lightest: hsl(100, 51.5%, 75.9%);
 
-  --col-deepblue-darkest: hsl(202, 81.4%, 9.1%);
-  --col-deepblue-darker: hsl(202, 81.4%, 16.1%);
-  --col-deepblue-dark: hsl(202, 81.4%, 23.1%);
-  --col-deepblue: hsl(202, 81.4%, 30.1%);
-  --col-deepblue-light: hsl(202, 81.4%, 37.1%);
-  --col-deepblue-lighter: hsl(202, 81.4%, 44.1%);
-  --col-deepblue-lightest: hsl(202, 81.4%, 51.1%);
+  --color-deepblue-darkest: hsl(202, 81.4%, 9.1%);
+  --color-deepblue-darker: hsl(202, 81.4%, 16.1%);
+  --color-deepblue-dark: hsl(202, 81.4%, 23.1%);
+  --color-deepblue: hsl(202, 81.4%, 30.1%);
+  --color-deepblue-light: hsl(202, 81.4%, 37.1%);
+  --color-deepblue-lighter: hsl(202, 81.4%, 44.1%);
+  --color-deepblue-lightest: hsl(202, 81.4%, 51.1%);
 }
 
 BODY {
-  --body-bg: var(--col-1);
-  --body-color: var(--col-4);
-  --link-color: var(--col-deepblue);
+  --body-bg: var(--color-1);
+  --body-color: var(--color-4);
+  --link-color: var(--color-deepblue);
 
-  --accent: var(--col-green-dark);
+  --accent: var(--color-green-dark);
 
-  --headers-color: var(--col-deepblue);
+  --headers-color: var(--color-deepblue);
 
-  --aside-bg: var(--col-4);
+  --aside-bg: var(--color-4);
 
-  --mark-bg: var(--col-deepblue-dark);
-  --mark-color: var(--col-2-light);
+  --mark-bg: var(--color-deepblue-dark);
+  --mark-color: var(--color-2-light);
 
-  --code-bg: var(--col-3-lighter);
-  --term-color: var(--col-deepblue-darker);
+  --code-bg: var(--color-3-lighter);
+  --term-color: var(--color-deepblue-darker);
 }

--- a/src/scss/global/layout.scss
+++ b/src/scss/global/layout.scss
@@ -25,5 +25,5 @@
   justify-content: space-between;
   margin-top: 3rem;
   padding-top: 1em;
-  border-top: 1px solid var(--col-2);
+  border-top: 1px solid var(--color-2);
 }


### PR DESCRIPTION
“Col” is an unusual short version of the ”color“ word. “Col” as “column” is much more common, remember `colspan`? Since the UI is using tables with _columns_ it becomes even more confusing.

<img width="385" alt="image" src="https://user-images.githubusercontent.com/105274/78013741-9a815800-734f-11ea-8224-6a625c395b7e.png">

I’d suggest using the “color” word as it is, it’s just two letters longer and removes any confusion. Unfortunately the longest variables won’t fit the cells with the full “color” word in them, so I had to also add `white-space: nowrap` and now it looks totally fine:

<img width="388" alt="image" src="https://user-images.githubusercontent.com/105274/78014375-8558f900-7350-11ea-9734-a91fdf8d3555.png">
